### PR TITLE
chore: change ci bun install to be app specific

### DIFF
--- a/.github/workflows/api-ci.yaml
+++ b/.github/workflows/api-ci.yaml
@@ -25,7 +25,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --cwd apps/api
 
       - name: Lint
         run: bun run lint:api

--- a/.github/workflows/web-ci.yaml
+++ b/.github/workflows/web-ci.yaml
@@ -23,7 +23,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --cwd apps/web
 
       - name: Lint
         run: bun run lint:web


### PR DESCRIPTION
Updated ci step to bun install from app specific for web and api.