### PR TITLE
Fix/auth persistent redirect

### DIFF
--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -25,7 +25,7 @@ export function useAuthRedirect() {
     if (isConnected && hasSessionTokens() && isCalledFromVisitorPage) {
       router.push("/dashboard");
     }
-  }, [isConnected, router]);
+  }, [isConnected, router, pathname]);
 
   return { isConnected: isConnected && hasSessionTokens() };
 }


### PR DESCRIPTION
The useAuthRedirect hook is called in the customNavBar component, meaning that each time the customNavBar is created, the router.push(“dashboard”) is called if the user is connected.

Now, I make sure that the router.push is only called if the hook is called from a visitor page.